### PR TITLE
hotplug events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["usb", "libusb", "hardware", "bindings"]
 
 [dependencies]
 bit-set = "0.2.0"
-libusb-sys = { path = "../libusb-sys" }
+libusb-sys = { git = "https://github.com/uruha-komachin/libusb-sys" }
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["usb", "libusb", "hardware", "bindings"]
 
 [dependencies]
 bit-set = "0.2.0"
-libusb-sys = { git = "https://github.com/uruha-komachin/libusb-sys" }
+libusb-sys = { path = "../libusb-sys" }
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -13,7 +13,6 @@ pub struct ConfigDescriptor {
 
 impl Drop for ConfigDescriptor {
     fn drop(&mut self) {
-        eprintln!("Dropping a config descriptor");
         unsafe {
             libusb_free_config_descriptor(self.descriptor);
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -147,7 +147,7 @@ impl Context {
     }
 }
 
-extern "C" fn invoke_callback(_ctx: *mut libusb_context, device: *const libusb_device, event: i32, data: *mut std::ffi::c_void) -> i32 {
+extern "C" fn invoke_callback(_ctx: *mut libusb_context, device: *mut libusb_device, event: i32, data: *mut std::ffi::c_void) -> i32 {
     match HotPlugEvent::from_i32(event) {
         Some(event) => {
             let device = ManuallyDrop::new(unsafe { device::from_libusb(PhantomData, device as *mut libusb_device) });

--- a/src/context.rs
+++ b/src/context.rs
@@ -127,6 +127,10 @@ impl Context {
         unsafe { libusb_handle_events(self.context) };
     }
 
+		pub fn handle_events_timeout(&self, duration: &libc::timeval) {
+        unsafe { libusb_handle_events_timeout(self.context, duration) };
+		}
+
     /// Convenience function to open a device by its vendor ID and product ID.
     ///
     /// This function is provided as a convenience for building prototypes without having to

--- a/src/context.rs
+++ b/src/context.rs
@@ -127,9 +127,9 @@ impl Context {
         unsafe { libusb_handle_events(self.context) };
     }
 
-		pub fn handle_events_timeout(&self, duration: &libc::timeval) {
+    pub fn handle_events_timeout(&self, duration: &libc::timeval) {
         unsafe { libusb_handle_events_timeout(self.context, duration) };
-		}
+    }
 
     /// Convenience function to open a device by its vendor ID and product ID.
     ///

--- a/src/device.rs
+++ b/src/device.rs
@@ -20,7 +20,6 @@ pub struct Device<'a> {
 impl<'a> Drop for Device<'a> {
     /// Releases the device reference.
     fn drop(&mut self) {
-        eprintln!("Dropping a device");
         unsafe {
             libusb_unref_device(self.device);
         }

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -25,7 +25,6 @@ pub struct DeviceHandle<'a> {
 impl<'a> Drop for DeviceHandle<'a> {
     /// Closes the device.
     fn drop(&mut self) {
-        eprintln!("Dropping a device handle");
         unsafe {
             for iface in self.interfaces.iter() {
                 libusb_release_interface(self.handle, iface as c_int);

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -16,7 +16,6 @@ pub struct DeviceList<'a> {
 impl<'a> Drop for DeviceList<'a> {
     /// Frees the device list.
     fn drop(&mut self) {
-        eprintln!("Dropping a device lisst");
         unsafe {
             libusb_free_device_list(self.list, 1);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use device_list::{DeviceList, Devices};
 pub use device::Device;
 pub use device_handle::DeviceHandle;
 pub use hotplug::HotplugFilter;
+pub use event::HotPlugEvent;
 
 pub use fields::{Speed, TransferType, SyncType, UsageType, Direction, RequestType, Recipient, Version, request_type};
 pub use device_descriptor::DeviceDescriptor;


### PR DESCRIPTION
- added `handle_events_timeout` function
- updated the type of `device` parameter in `invoke_callback` to `*mut libusb_device`
- exposed `event::HotPlugEvent` so that user can do match in callback
- removed `eprintln!()` calls